### PR TITLE
Default to 80x80 terminal if the real size cannot be determined (fixes segfault)

### DIFF
--- a/main.c
+++ b/main.c
@@ -250,7 +250,10 @@ main(int argc, char *argv[])
     Term *term;
     struct winsize size;
 
-    ioctl(0, TIOCGWINSZ, &size);
+    if (ioctl(0, TIOCGWINSZ, &size) == -1) {
+        size.ws_row = 80;
+        size.ws_col = 80;
+    }
     set_defaults(&size);
     while ((opt = getopt(argc, argv, "o:m:d:l:f:h:w:c:qv")) != -1) {
         switch (opt) {


### PR DESCRIPTION
With this patch applied, congif can run with standard input from
/dev/null.

The 80x80 is just some random size I made up, which is not important,
since the size can be overridden using command line options.