### PR TITLE
Compile the default font into the executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ a.out
 *.t
 *.d
 *log
+default_font.h
+mbf2c

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,22 @@ PREFIX=/usr/local
 MANPREFIX=$(PREFIX)/man
 BINDIR=$(DESTDIR)$(PREFIX)/bin
 MANDIR=$(DESTDIR)$(MANPREFIX)/man1
+DEFAULT_FONT=misc-fixed-6x10.mbf
 
 HDR = term.h mbf.h gif.h
 SRC = ${HDR:.h=.c}
-EHDR = default.h cs_vtg.h cs_437.h
+EHDR = default.h cs_vtg.h cs_437.h default_font.h
 ESRC = main.c
 
 all: congif
 
 congif: $(HDR) $(EHDR) $(SRC) $(ESRC)
 	$(CC) $(CFLAGS) -o $@ $(SRC) $(ESRC)
+
+default_font.h: $(DEFAULT_FONT) mbf.h mbf.c mbf2c.c
+	$(CC) $(CFLAGS) -o mbf2c mbf.c mbf2c.c
+	./mbf2c $(DEFAULT_FONT) > fnt.tmp
+	mv fnt.tmp $@
 
 install: congif
 	rm -f $(BINDIR)/congif
@@ -24,4 +30,4 @@ uninstall: $(BINDIR)/congif
 	rm $(BINDIR)/congif
 	rm $(MANDIR)/congif.1
 clean:
-	$(RM) congif
+	$(RM) congif default_font.h mbf2c fnt.tmp

--- a/main.c
+++ b/main.c
@@ -14,6 +14,7 @@
 #include "term.h"
 #include "mbf.h"
 #include "gif.h"
+#include "default_font.h"
 
 #define MIN(A, B)   ((A) < (B) ? (A) : (B))
 #define MAX(A, B)   ((A) > (B) ? (A) : (B))
@@ -133,10 +134,14 @@ convert_script(Term *term)
         fprintf(stderr, "error: could not load dialogue: %s\n", options.dialogue);
         goto no_fd;
     }
-    font = load_font(options.font);
-    if (!font) {
-        fprintf(stderr, "error: could not load font: %s\n", options.font);
-        goto no_font;
+    if (options.font == 0) {
+	font = default_font;
+    } else {
+	font = load_font(options.font);
+	if (!font) {
+	    fprintf(stderr, "error: could not load font: %s\n", options.font);
+	    goto no_font;
+	}
     }
     w = term->cols * font->header.w;
     h = term->rows * font->header.h;
@@ -197,7 +202,7 @@ convert_script(Term *term)
     close_gif(gif);
     return 0;
 no_gif:
-    free(font);
+    if (options.font) free(font);
 no_font:
     close(fd);
 no_fd:
@@ -235,7 +240,7 @@ set_defaults()
     options.maxdelay = FLT_MAX;
     options.divisor = 1.0;
     options.loop = -1;
-    options.font = "misc-fixed-6x10.mbf";
+    options.font = 0;
     options.cursor = 1;
     options.quiet = 0;
     options.barsize = 0;

--- a/mbf2c.c
+++ b/mbf2c.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/stat.h>
+
+#include "mbf.h"
+
+#define MAX_NAME    0x10
+#define FN	    "default_font"
+
+int
+main(int argc, char *argv[])
+{
+    Font *font;
+    int i;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s font.mbf\n", argv[0]);
+        return 1;
+    }
+    font = load_font(argv[1]);
+    if (font == NULL) {
+        fprintf(stderr, "Failed to load font '%s'.\n", argv[1]);
+        return 1;
+    }
+
+    printf("static Range "FN"_ranges[%d] = {\n", font->header.nr);
+    for(i=0; i<font->header.nr; i++) {
+        printf("    { %d, %d }%s\n",
+            (int) font->ranges[i].offset,
+            (int) font->ranges[i].length,
+            i+1 == font->header.nr?"":",");
+    }
+    printf("};\n\n");
+
+    printf("static uint8_t "FN"_data[] = {\n");
+    for (i = 0; i < font->header.ng * font->stride * font->header.h; i++) {
+        if (i%12 == 0) {
+            if (i) printf(",\n");
+            printf("    ");
+        } else
+            printf(", ");
+        printf("0x%02x", font->data[i]);
+    }
+    printf("\n};\n\n");
+
+    printf("Font "FN"[1] = {{ ");
+
+    printf("{ %d, %d, %d, %d }, ",
+        (int) font->header.ng,
+        (int) font->header.w,
+        (int) font->header.h,
+        (int) font->header.nr);
+
+    printf("%d, "FN"_ranges, "FN"_data }};\n",
+        (int) font->stride);
+
+    free(font);
+    return 0;
+}


### PR DESCRIPTION
Compile the default font into the executable rather than a default font file name.

This makes it easier to "install" as there's no font file to find.

Just this one patch should be standalone.
