### PR TITLE
Patch upgrades to Linux emulation (1)

### DIFF
--- a/term.c
+++ b/term.c
@@ -329,6 +329,8 @@ escseq(Term *term, uint8_t byte)
             break;
         case 'K':
             logfmt("UNS: user-defined mapping\n");
+            term->cs_array[0] = CS_BMP;
+            break;
         }
         break;
     case ')':
@@ -344,6 +346,8 @@ escseq(Term *term, uint8_t byte)
             break;
         case 'K':
             logfmt("UNS: user-defined mapping\n");
+            term->cs_array[1] = CS_BMP;
+            break;
         }
         break;
     case '>':

--- a/term.c
+++ b/term.c
@@ -223,8 +223,9 @@ ctrlchar(Term *term, uint8_t byte)
         if (term->col) term->col--;
         break;
     case 0x09:
-        /* TODO: go to next tab stop or end of line */
-        logfmt("NYI: Control Character 0x09 (TAB)\n");
+        /* TODO: See ESC Sequence H (HTS) */
+        term->col &= ~7; term->col += 8;
+        CLIPCOL(term->cols-1);
         break;
     case 0x0A: case 0x0B: case 0x0C:
         linefeed(term);

--- a/term.c
+++ b/term.c
@@ -298,8 +298,23 @@ escseq(Term *term, uint8_t byte)
         logfmt("NYI: ESC Sequence %% (character set selection)\n");
         break;
     case '#':
-        /* TODO: DEC screen alignment test */
-        logfmt("NYI: ESC Sequence # (DECALN)\n");
+        switch(second)
+        {
+        case '8':
+            {
+                int i, j;
+                for (i = 0; i < term->rows; i++) {
+                    for (j = 0; j < term->cols; j++) {
+                        term->addr[i][j] = (Cell) {'E', def_attr, def_pair};
+                    }
+                }
+            }
+            break;
+        default:
+            /* TODO */
+            logfmt("NYI: ESC Sequence # 3..6 DECDWL etc\n");
+            break;
+        }
         break;
     case '(':
         switch (second) {

--- a/term.h
+++ b/term.h
@@ -23,7 +23,7 @@
 
 #define EMPTY       0x0020
 #define BCE         1
-#if BCE
+#if !BCE
   #define BLANK (Cell) {EMPTY, def_attr, def_pair}
 #else
   #define BLANK (Cell) {EMPTY, term->attr, term->pair}

--- a/term.h
+++ b/term.h
@@ -39,7 +39,7 @@ typedef struct Cell {
 } Cell;
 
 typedef enum CharSet {CS_BMP, CS_VTG, CS_437} CharSet;
-typedef enum State {S_ANY, S_ESC, S_CSI, S_OSC, S_UNI} State;
+typedef enum State {S_ANY, S_ESC, S_CSI, S_OSC, S_OSCESC, S_STR, S_STRESC, S_UNI} State;
 
 typedef struct SaveCursor {
     int row, col;


### PR DESCRIPTION
These patches are upgrades to your emulation to bring it closer to the current kernel emulations.
The BCE was toggled the wrong way Linux (and most other emulators) use the Current background colour to clear areas.
Malformed UTF8 was being printed as "weird stuff" now if you print some ISO-8859-1 it'll just print U+FFFD.
Tabs (without redefinition) and DECALN are just trivial, tabs tend to be used by `ls`.
The OSC eating is to allow `vim` to be run, it has the habit of trying some `xterm` strings in the hope that they'll work; if they don't it doesn't mind, but this change stops it making a mess.

* a5d1803 (HEAD -> patch-upgrade, origin/patch-upgrade) Make user defined set "K" same as default.
* 83c7cde Add DECALN
* 570f380 Eat OSC and other string sequences without interpretation.
* 7b8e2c8 Add default tabs at 8 spaces.
* 65b1760 Discard obviously malformed UTF8
* db7094f Turned on BCE
