### PR TITLE
Patch upgrade2 -- Colours

### DIFF
--- a/main.c
+++ b/main.c
@@ -57,7 +57,7 @@ get_pair(Term *term, int row, int col)
         fore = 0x2;
     if (cell.attr & A_BOLD)
         fore |= 0x8;
-    if (cell.attr & A_BLINK)
+    if (cell.attr & A_BRIGHTBG)
         back |= 0x8;
     if ((cell.attr & A_INVISIBLE) != 0) fore = back;
     return (fore << 4) | (back & 0xF);

--- a/main.c
+++ b/main.c
@@ -39,7 +39,6 @@ get_pair(Term *term, int row, int col)
     uint8_t fore, back;
     int inverse;
 
-    /* TODO: add support for A_INVISIBLE */
     inverse = term->mode & M_REVERSE;
     if (term->mode & M_CURSORVIS)
         inverse = term->row == row && term->col == col ? !inverse : inverse;
@@ -60,6 +59,7 @@ get_pair(Term *term, int row, int col)
         fore |= 0x8;
     if (cell.attr & A_BLINK)
         back |= 0x8;
+    if ((cell.attr & A_INVISIBLE) != 0) fore = back;
     return (fore << 4) | (back & 0xF);
 }
 

--- a/term.c
+++ b/term.c
@@ -445,6 +445,9 @@ sgr(Term *term, int number)
     case 7:
         term->attr |= A_INVERSE;
         break;
+    case 8:
+        term->attr |= A_INVISIBLE;
+        break;
     case 10:
         /* TODO: reset toggle meta flag */
         term->cs_array[term->cs_index = 0] = CS_BMP;

--- a/term.c
+++ b/term.c
@@ -495,6 +495,14 @@ sgr(Term *term, int number)
     case 49:
         term->pair = (term->pair & 0xF0) | DEF_BACK;
         break;
+    case 90: case 91: case 92: case 93: case 94: case 95: case 96: case 97:
+        term->pair = ((number - 90) << 4) | (term->pair & 0x0F);
+        term->attr |= A_BOLD;
+        break;
+    case 100: case 101: case 102: case 103: case 104: case 105: case 106: case 107:
+        term->pair = (term->pair & 0xF0) | (number - 100);
+        term->attr |= A_BRIGHTBG;
+        break;
     default:
         logfmt("UNS: SGR %d\n", number);
     }

--- a/term.h
+++ b/term.h
@@ -7,6 +7,7 @@
 #define A_INVERSE   0x20
 #define A_INVISIBLE 0x40
 #define A_CROSSED   0x80
+#define A_BRIGHTBG  A_BLINK
 
 #define M_DISPCTRL  0x0001
 #define M_INSERT    0x0002


### PR DESCRIPTION
The current linux kernel emulation understands CSI90..107 and the 256 and 16M colour modes, however, it doesn't do anything useful with the latter two EXCEPT that it doesn't break by changing the attributes almost randomly.

Linux's "support" of the 256 and 16M colour modes is better than this though, it changes the colour to the one of the 16 colours "closest" to the request (by some measure).

* 1f3cd20 (HEAD -> patch-upgrade2) Added code to ignore 256 and 16M colour sequences.
* ab5dc4f Process CSI 90..107 m for bright colours
* 9d1017d Process CSI 8 m for trivial A_INVISIBLE
