### PR TITLE
Update attribute rendering process

### DIFF
--- a/main.c
+++ b/main.c
@@ -45,20 +45,21 @@ get_pair(Term *term, int row, int col)
         inverse = term->row == row && term->col == col ? !inverse : inverse;
     cell = term->addr[row][col];
     inverse = cell.attr & A_INVERSE ? !inverse : inverse;
-    if (inverse) {
-        fore = cell.pair & 0xF;
-        back = cell.pair >> 4;
-    } else {
-        fore = cell.pair >> 4;
-        back = cell.pair & 0xF;
-    }
-    if (cell.attr & (A_DIM | A_UNDERLINE))
-        fore = 0x6;
-    else if (cell.attr & (A_ITALIC | A_CROSSED))
+    fore = cell.pair >> 4;
+    back = cell.pair & 0xF;
+    if (cell.attr & (A_ITALIC | A_CROSSED))
         fore = 0x2;
+    else if (cell.attr & A_UNDERLINE)
+        fore = 0x6;
+    else if (cell.attr & A_DIM)
+        fore = 0x8;
+    if (inverse) {
+        uint8_t t;
+        t = fore; fore = back; back = t;
+    }
     if (cell.attr & A_BOLD)
         fore |= 0x8;
-    if (cell.attr & A_BRIGHTBG)
+    if (cell.attr & A_BLINK)
         back |= 0x8;
     if ((cell.attr & A_INVISIBLE) != 0) fore = back;
     return (fore << 4) | (back & 0xF);

--- a/term.c
+++ b/term.c
@@ -487,6 +487,9 @@ sgr(Term *term, int n, int *params)
         case 2:
             term->attr |= A_DIM;
             break;
+        case 3:
+            term->attr |= A_ITALIC;
+            break;
         case 4:
             term->attr |= A_UNDERLINE;
             break;
@@ -515,10 +518,16 @@ sgr(Term *term, int n, int *params)
             term->mode |= M_DISPCTRL;
             break;
         case 21:
-            term->attr &= ~A_BOLD;
+#ifndef OLDLINUX
+            term->attr |= A_UNDERLINE; /* Linux say should be: DOUBLE_ULINE */
             break;
+#endif
         case 22:
             term->attr &= ~A_DIM;
+            term->attr &= ~A_BOLD;
+            break;
+        case 23:
+            term->attr &= ~A_ITALIC;
             break;
         case 24:
             term->attr &= ~A_UNDERLINE;
@@ -588,12 +597,10 @@ sgr(Term *term, int n, int *params)
             term->pair = (term->pair & 0xF0) | DEF_BACK;
             break;
         case 90: case 91: case 92: case 93: case 94: case 95: case 96: case 97:
-            term->pair = ((number - 90) << 4) | (term->pair & 0x0F);
-            term->attr |= A_BOLD;
+            term->pair = ((number - 90 + 8) << 4) | (term->pair & 0x0F);
             break;
         case 100: case 101: case 102: case 103: case 104: case 105: case 106: case 107:
-            term->pair = (term->pair & 0xF0) | (number - 100);
-            term->attr |= A_BRIGHTBG;
+            term->pair = (term->pair & 0xF0) | (number - 100 + 8);
             break;
         default:
             logfmt("UNS: SGR %d\n", number);

--- a/term.h
+++ b/term.h
@@ -7,7 +7,6 @@
 #define A_INVERSE   0x20
 #define A_INVISIBLE 0x40
 #define A_CROSSED   0x80
-#define A_BRIGHTBG  A_BLINK
 
 #define M_DISPCTRL  0x0001
 #define M_INSERT    0x0002


### PR DESCRIPTION
I definitely remember the hassle getting this attribute mapping in the right order with previous incarnations.
Luckily I still have the test scripts so this is hopefully now exactly the same as Linux and very close to the other emulators. (Linux's random colours for other attributes is somewhat unique though)

............
Change CSI m values to turn off attributes; looks like various old
Linux inaccuracies.

I shouldn't have added the BRIGHTBG bit as it already exists.
Redo attribute merging to match XTerm and console orders.