### PR TITLE
Various fixes -- MIN/MAX delay controls, empty frame.

### DIFF
--- a/gif.c
+++ b/gif.c
@@ -218,6 +218,7 @@ add_frame(GIF *gif, uint16_t d)
         set_delay(gif, d);
     if (!get_bbox(gif, &w, &h, &x, &y)) {
         /* image's not changed; save one pixel just to add delay */
+        if (!d) return;
         w = h = 1;
         x = y = 0;
     }

--- a/main.c
+++ b/main.c
@@ -119,7 +119,7 @@ convert_script(Term *term)
     int w, h;
     int i, c;
     float d;
-    uint16_t rd;
+    uint16_t rd, id = 0;
     float lastdone, done;
     char pb[options.barsize+1];
     GIF *gif;
@@ -178,11 +178,12 @@ convert_script(Term *term)
             }
         }
         d += (MIN(t, options.maxdelay) * 100.0 / options.divisor);
-        rd = (uint16_t) (d + 0.5);
+        rd = (uint16_t) MIN((int)(d + 0.5), 65535);
         if (i && rd >= MIN_DELAY) {
             render(term, font, gif, rd);
             d = 0;
         }
+        if (i == 0) { id = rd; rd = 0; d = 0; }
         while (n--) {
             read(fd, &ch, 1);
             parse(term, ch);
@@ -191,6 +192,7 @@ convert_script(Term *term)
             term->mode &= ~M_CURSORVIS;
         i++;
     }
+    rd += id;
     if (options.barsize) {
         while (lastdone < options.barsize-2) {
             putchar('#');
@@ -198,7 +200,7 @@ convert_script(Term *term)
         }
         putchar('\n');
     }
-    render(term, font, gif, MAX(rd, MIN_DELAY));
+    render(term, font, gif, MAX(rd, 1));
     close_gif(gif);
     return 0;
 no_gif:


### PR DESCRIPTION
MIN/MAX delay controls ...

Make sure delay doesn't exceed 65535, the limit of the format.

Don't extend the last frame to MIN_DELAY, but don't use zero as some
player assume that's an error and extend it to the previous value.

GIF cannot represent a time interval before the first frame. Instead of
moving the script delay after the first frame move it after the last frame
so that it's still between the first and last frames when we're looping.

No need to add an empty frame if there are no pixels and the delay is zero.
